### PR TITLE
Start Implementing e2e like tests

### DIFF
--- a/langserver/cache/cache.go
+++ b/langserver/cache/cache.go
@@ -84,12 +84,15 @@ func (c *DocumentCache) AddDocument(doc *protocol.TextDocumentItem) (*Document, 
 // Additionally returns a context that expires as soon as the document changes
 func (c *DocumentCache) GetDocument(uri protocol.DocumentUri) (*Document, context.Context, error) {
 	c.mu.RLock()
+	defer c.mu.RUnlock()
 	ret, ok := c.documents[uri]
-	c.mu.RUnlock()
 
 	if !ok {
 		return nil, nil, jsonrpc2.NewErrorf(jsonrpc2.CodeInternalError, "cache/getDocument: Document not found: %v", uri)
 	}
+
+	ret.mu.RLock()
+	defer ret.mu.RUnlock()
 
 	return ret, ret.versionCtx, nil
 }

--- a/langserver/cache/cache.go
+++ b/langserver/cache/cache.go
@@ -15,6 +15,7 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"go/token"
 	"sync"
 
@@ -47,6 +48,10 @@ func (c *DocumentCache) Init() {
 
 // AddDocument adds a Document to the cache
 func (c *DocumentCache) AddDocument(doc *protocol.TextDocumentItem) (*Document, error) {
+	if _, ok := c.documents[doc.URI]; ok {
+		return nil, errors.New("document already exists")
+	}
+
 	file := c.fileSet.AddFile(doc.URI, -1, maxDocumentSize)
 
 	if r := recover(); r != nil {

--- a/langserver/cache/cache_test.go
+++ b/langserver/cache/cache_test.go
@@ -26,7 +26,7 @@ func TestCache(t *testing.T) {
 
 	doc, err := c.AddDocument(&protocol.TextDocumentItem{
 		URI:        "test_file",
-		LanguageID: "test_language",
+		LanguageID: "yaml",
 		Version:    0,
 		Text:       "test_text",
 	})
@@ -37,8 +37,8 @@ func TestCache(t *testing.T) {
 	_, err = c.AddDocument(&protocol.TextDocumentItem{
 
 		URI:        "test_file",
-		LanguageID: "test_language",
-		Version:    0,
+		LanguageID: "yaml",
+		Version:    1,
 		Text:       "test_text",
 	})
 	if err == nil {
@@ -62,7 +62,7 @@ func TestCache(t *testing.T) {
 	_, err = c.AddDocument(&protocol.TextDocumentItem{
 
 		URI:        "test_file",
-		LanguageID: "test_language",
+		LanguageID: "yaml",
 		Version:    0,
 		Text:       "test_text",
 	})

--- a/langserver/cache/cache_test.go
+++ b/langserver/cache/cache_test.go
@@ -1,0 +1,72 @@
+// Copyright 2019 Tobias Guggenmos
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/slrtbtfs/promql-lsp/vendored/go-tools/lsp/protocol"
+)
+
+func TestCache(t *testing.T) {
+	c := &DocumentCache{}
+
+	c.Init()
+
+	doc, err := c.AddDocument(&protocol.TextDocumentItem{
+		URI:        "test_file",
+		LanguageID: "test_language",
+		Version:    0,
+		Text:       "test_text",
+	})
+	if err != nil {
+		panic("Failed to AddDocument() to cache")
+	}
+
+	_, err = c.AddDocument(&protocol.TextDocumentItem{
+
+		URI:        "test_file",
+		LanguageID: "test_language",
+		Version:    0,
+		Text:       "test_text",
+	})
+	if err == nil {
+		panic("Should not be able to add same document twice")
+	}
+
+	doc1, _, err := c.GetDocument("test_file")
+	if err != nil {
+		panic("Failed to GetDocument() from cache")
+	}
+
+	if doc1 != doc {
+		panic("Cache returned wrong document")
+	}
+
+	err = c.RemoveDocument("test_file")
+	if err != nil {
+		panic("Failed to RemoveDocument() from cache")
+	}
+
+	_, err = c.AddDocument(&protocol.TextDocumentItem{
+
+		URI:        "test_file",
+		LanguageID: "test_language",
+		Version:    0,
+		Text:       "test_text",
+	})
+	if err != nil {
+		panic("Should be able to readd document after removing it")
+	}
+}

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -218,7 +218,7 @@ func (d *dummyStream) Push(text []byte) {
 }
 
 // TestServerState tries to emulate a full server lifetime
-func TestServerState(t *testing.T) { //nolint:funlen
+func TestServer(t *testing.T) { //nolint:funlen
 	stream := &dummyStream{}
 	_, s := ServerFromStream(context.Background(), stream, &Config{})
 
@@ -254,6 +254,26 @@ func TestServerState(t *testing.T) { //nolint:funlen
 	})
 	if err != nil {
 		panic("Failed to open document")
+	}
+
+	// Apply a Full Change to the document
+	err = s.DidChange(context.Background(), &protocol.DidChangeTextDocumentParams{
+		TextDocument: protocol.VersionedTextDocumentIdentifier{
+			Version: 1,
+			TextDocumentIdentifier: protocol.TextDocumentIdentifier{
+				URI: "test.promql",
+			},
+		},
+		ContentChanges: []protocol.TextDocumentContentChangeEvent{
+			{
+				Range:       nil,
+				RangeLength: 0,
+				Text:        "metric_name",
+			},
+		},
+	})
+	if err != nil {
+		panic("Failed to apply full change to document")
 	}
 
 	// Close a document

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -217,8 +217,8 @@ func (d *dummyStream) Push(text []byte) {
 	d.readQueue = append(d.readQueue, text...)
 }
 
-// TestServer tries to emulate a full server lifetime
-func TestServer(t *testing.T) {
+// TestServerState tries to emulate a full server lifetime
+func TestServerState(t *testing.T) { //nolint:funlen
 	stream := &dummyStream{}
 	_, s := ServerFromStream(context.Background(), stream, &Config{})
 
@@ -236,6 +236,42 @@ func TestServer(t *testing.T) {
 	err = s.Initialized(context.Background(), &protocol.InitializedParams{})
 	if err != nil {
 		panic("Failed to initialize Server")
+	}
+
+	// Add a document to the server
+	err = s.DidOpen(context.Background(), &protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{
+			URI:        "test.promql",
+			LanguageID: "promql",
+			Version:    0,
+			Text:       "",
+		},
+	})
+	if err != nil {
+		panic("Failed to open document")
+	}
+
+	// Close a document
+	err = s.DidClose(context.Background(), &protocol.DidCloseTextDocumentParams{
+		TextDocument: protocol.TextDocumentIdentifier{
+			URI: "test.promql",
+		},
+	})
+	if err != nil {
+		panic("Failed to close document")
+	}
+
+	// Reopen a closed document
+	err = s.DidOpen(context.Background(), &protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{
+			URI:        "test.promql",
+			LanguageID: "promql",
+			Version:    0,
+			Text:       "",
+		},
+	})
+	if err != nil {
+		panic("Failed to reopen document")
 	}
 
 	err = s.Initialized(context.Background(), &protocol.InitializedParams{})

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -1,0 +1,197 @@
+// Copyright 2019 Tobias Guggenmos
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package langserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/slrtbtfs/promql-lsp/vendored/go-tools/jsonrpc2"
+	"github.com/slrtbtfs/promql-lsp/vendored/go-tools/lsp/protocol"
+)
+
+// TestNotImplemented checks whether unimplemented functions return the approbiate Error
+func TestNotImplemented(*testing.T) { // nolint: gocognit, funlen, gocyclo
+	s := &server{}
+
+	err := s.DidChangeWorkspaceFolders(context.Background(), &protocol.DidChangeWorkspaceFoldersParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	err = s.DidChangeConfiguration(context.Background(), &protocol.DidChangeConfigurationParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	err = s.DidSave(context.Background(), &protocol.DidSaveTextDocumentParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	err = s.WillSave(context.Background(), &protocol.WillSaveTextDocumentParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	err = s.DidChangeWatchedFiles(context.Background(), &protocol.DidChangeWatchedFilesParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	err = s.Progress(context.Background(), &protocol.ProgressParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.SelectionRange(context.Background(), &protocol.SelectionRangeParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	err = s.SetTraceNotification(context.Background(), &protocol.SetTraceParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	err = s.LogTraceNotification(context.Background(), &protocol.LogTraceParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.Implementation(context.Background(), &protocol.ImplementationParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.TypeDefinition(context.Background(), &protocol.TypeDefinitionParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.DocumentColor(context.Background(), &protocol.DocumentColorParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.ColorPresentation(context.Background(), &protocol.ColorPresentationParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.FoldingRange(context.Background(), &protocol.FoldingRangeParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.Declaration(context.Background(), &protocol.DeclarationParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.WillSaveWaitUntil(context.Background(), &protocol.WillSaveTextDocumentParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.Resolve(context.Background(), &protocol.CompletionItem{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.SignatureHelp(context.Background(), &protocol.SignatureHelpParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.Definition(context.Background(), &protocol.DefinitionParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.References(context.Background(), &protocol.ReferenceParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.DocumentHighlight(context.Background(), &protocol.DocumentHighlightParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.DocumentSymbol(context.Background(), &protocol.DocumentSymbolParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.CodeAction(context.Background(), &protocol.CodeActionParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.Symbol(context.Background(), &protocol.WorkspaceSymbolParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.CodeLens(context.Background(), &protocol.CodeLensParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.ResolveCodeLens(context.Background(), &protocol.CodeLens{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.Formatting(context.Background(), &protocol.DocumentFormattingParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.RangeFormatting(context.Background(), &protocol.DocumentRangeFormattingParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.OnTypeFormatting(context.Background(), &protocol.DocumentOnTypeFormattingParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.Rename(context.Background(), &protocol.RenameParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.PrepareRename(context.Background(), &protocol.PrepareRenameParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.DocumentLink(context.Background(), &protocol.DocumentLinkParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.ResolveDocumentLink(context.Background(), &protocol.DocumentLink{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+
+	_, err = s.ExecuteCommand(context.Background(), &protocol.ExecuteCommandParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+	}
+}

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -207,12 +207,42 @@ func (d *dummyStream) Read(_ context.Context) ([]byte, int64, error) {
 
 	return ret, int64(len(ret)), nil
 }
+
 func (d *dummyStream) Write(_ context.Context, text []byte) (int64, error) {
 	return int64(len(text)), nil
 }
 
-// TestNonExistentDocumentFailure checks whether Commands that are told to operate
-// on non existent Documents fail
-func TestNonExistentDocumentFailure(t *testing.T) {
+// Push adds a text to the readQueue
+func (d *dummyStream) Push(text []byte) {
+	d.readQueue = append(d.readQueue, text...)
+}
 
+// TestServer tries to emulate a full server lifetime
+func TestServer(t *testing.T) {
+	stream := &dummyStream{}
+	_, s := ServerFromStream(context.Background(), stream, &Config{})
+
+	// Initialize Server
+	_, err := s.Initialize(context.Background(), &protocol.ParamInitia{})
+	if err != nil {
+		panic("Failed to initialize Server")
+	}
+
+	// Confirm Initialisation
+	err = s.Initialized(context.Background(), &protocol.InitializedParams{})
+	if err != nil {
+		panic("Failed to initialize Server")
+	}
+
+	// Shutdown Server
+	err = s.Shutdown(context.Background())
+	if err != nil {
+		panic("Failed to initialize Server")
+	}
+
+	// Confirm Shutdown
+	err = s.Exit(context.Background())
+	if err != nil {
+		panic("Failed to initialize Server")
+	}
 }

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -195,3 +195,24 @@ func TestNotImplemented(*testing.T) { // nolint: gocognit, funlen, gocyclo
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 }
+
+// dummyStream is a fake jsonrpc2.Stream for Test purposes
+type dummyStream struct { //nolint:unused
+	readQueue []byte
+}
+
+func (d *dummyStream) Read(_ context.Context) ([]byte, int64, error) {
+	ret := d.readQueue
+	d.readQueue = []byte{}
+
+	return ret, int64(len(ret)), nil
+}
+func (d *dummyStream) Write(_ context.Context, text []byte) (int64, error) {
+	return int64(len(text)), nil
+}
+
+// TestNonExistentDocumentFailure checks whether Commands that are told to operate
+// on non existent Documents fail
+func TestNonExistentDocumentFailure(t *testing.T) {
+
+}

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -228,10 +228,19 @@ func TestServer(t *testing.T) {
 		panic("Failed to initialize Server")
 	}
 
+	_, err = s.Initialize(context.Background(), &protocol.ParamInitia{})
+	if err == nil {
+		panic("cannot initialize server twice")
+	}
 	// Confirm Initialisation
 	err = s.Initialized(context.Background(), &protocol.InitializedParams{})
 	if err != nil {
 		panic("Failed to initialize Server")
+	}
+
+	err = s.Initialized(context.Background(), &protocol.InitializedParams{})
+	if err == nil {
+		panic("cannot confirm server initialisation twice")
 	}
 
 	// Shutdown Server
@@ -240,9 +249,16 @@ func TestServer(t *testing.T) {
 		panic("Failed to initialize Server")
 	}
 
-	// Confirm Shutdown
-	err = s.Exit(context.Background())
-	if err != nil {
-		panic("Failed to initialize Server")
+	err = s.Shutdown(context.Background())
+	if err == nil {
+		panic("cannot shutdown server twice")
 	}
-}
+	/*
+		// Left out until it does something else than calling os.Exit()
+		// Confirm Shutdown
+		err = s.Exit(context.Background())
+		if err != nil {
+			panic("Failed to initialize Server")
+		}
+	*/
+} // nolint:wsl

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -238,6 +238,11 @@ func TestServerState(t *testing.T) { //nolint:funlen
 		panic("Failed to initialize Server")
 	}
 
+	err = s.Initialized(context.Background(), &protocol.InitializedParams{})
+	if err == nil {
+		panic("cannot confirm server initialisation twice")
+	}
+
 	// Add a document to the server
 	err = s.DidOpen(context.Background(), &protocol.DidOpenTextDocumentParams{
 		TextDocument: protocol.TextDocumentItem{
@@ -272,11 +277,6 @@ func TestServerState(t *testing.T) { //nolint:funlen
 	})
 	if err != nil {
 		panic("Failed to reopen document")
-	}
-
-	err = s.Initialized(context.Background(), &protocol.InitializedParams{})
-	if err == nil {
-		panic("cannot confirm server initialisation twice")
 	}
 
 	// Shutdown Server

--- a/langserver/notImplemented.go
+++ b/langserver/notImplemented.go
@@ -15,8 +15,6 @@ package langserver
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	"github.com/slrtbtfs/promql-lsp/vendored/go-tools/jsonrpc2"
 	"github.com/slrtbtfs/promql-lsp/vendored/go-tools/lsp/protocol"
@@ -24,7 +22,6 @@ import (
 
 func notImplemented(method string) *jsonrpc2.Error {
 	err := jsonrpc2.NewErrorf(jsonrpc2.CodeMethodNotFound, "method %q no yet implemented", method)
-	fmt.Fprint(os.Stderr, err.Error())
 
 	return err
 }


### PR DESCRIPTION
This adds a test that simulates the lifetime of a server.

It also significantly brings the language server closer to having the tests described in #31, #26 and #14.

On the way several bugs were uncovered and fixed.

Signed-off-by: Tobias Guggenmos <tguggenm@redhat.com>